### PR TITLE
[Enhancement] Support for Stickers and GIFs

### DIFF
--- a/src/main/java/top/xujiayao/mcdiscordchat/discord/DiscordEventListener.java
+++ b/src/main/java/top/xujiayao/mcdiscordchat/discord/DiscordEventListener.java
@@ -355,7 +355,7 @@ public class DiscordEventListener extends ListenerAdapter {
 
 			// ignore Discord's built in gifs, can only be one
 			if (StringUtils.startsWith(referencedMessage, "https://tenor.com/view")) {
-				referencedMessage.append("<gif>");
+				referencedMessage.append(Formatting.YELLOW).append("<gif>");
 			}
 
 			if (StringUtils.countMatches(referencedMessage, ":") >= 2) {

--- a/src/main/java/top/xujiayao/mcdiscordchat/discord/DiscordEventListener.java
+++ b/src/main/java/top/xujiayao/mcdiscordchat/discord/DiscordEventListener.java
@@ -354,7 +354,9 @@ public class DiscordEventListener extends ListenerAdapter {
 			}
 
 			// ignore Discord's built in gifs, can only be one
-			if (StringUtils.startsWith(referencedMessage, "https://tenor.com/view")) {
+			if (StringUtils.startsWith(referencedMessage, "https://")
+					&& StringUtils.endsWith(referencedMessage, ".gif")
+					&& StringUtils.contains(referencedMessage, "tenor.com")) {
 				referencedMessage.append(Formatting.YELLOW).append("<gif>");
 			}
 

--- a/src/main/java/top/xujiayao/mcdiscordchat/discord/DiscordEventListener.java
+++ b/src/main/java/top/xujiayao/mcdiscordchat/discord/DiscordEventListener.java
@@ -348,15 +348,12 @@ public class DiscordEventListener extends ListenerAdapter {
 			}
 
 			if (!e.getMessage().getReferencedMessage().getStickers().isEmpty()) {
-				for (MessageSticker sticker : e.getMessage().getReferencedMessage().getStickers()) {
+				if (!e.getMessage().getReferencedMessage().getContentDisplay().isBlank()) {
+					referencedMessage.append(" ");
+				}
+				for (MessageSticker ignored : e.getMessage().getReferencedMessage().getStickers()) {
 					referencedMessage.append(Formatting.YELLOW).append("<sticker>");
 				}
-			}
-
-			// ignore Discord's built in gifs, can only be one
-			if (StringUtils.startsWith(referencedMessage, "https://")
-					&& StringUtils.contains(referencedMessage, "tenor.com")) {
-				referencedMessage.append(Formatting.YELLOW).append("<gif>");
 			}
 
 			if (StringUtils.countMatches(referencedMessage, ":") >= 2) {
@@ -388,33 +385,26 @@ public class DiscordEventListener extends ListenerAdapter {
 
 			finalReferencedMessage = MarkdownParser.parseMarkdown(referencedMessage.toString());
 
-			if (finalReferencedMessage.contains("http://")) {
-				String[] links = StringUtils.substringsBetween(finalReferencedMessage, "http://", " ");
-				if (!StringUtils.substringAfterLast(finalReferencedMessage, "http://").contains(" ")) {
-					links = ArrayUtils.add(links, StringUtils.substringAfterLast(finalReferencedMessage, "http://"));
-				}
-				for (String link : links) {
-					if (link.contains("\n")) {
-						link = StringUtils.substringBefore(link, "\n");
+			for (String protocol : new String[]{"http://", "https://"}) {
+				if (finalReferencedMessage.contains(protocol)) {
+					String[] links = StringUtils.substringsBetween(finalReferencedMessage, protocol, " ");
+					if (!StringUtils.substringAfterLast(finalReferencedMessage, protocol).contains(" ")) {
+						links = ArrayUtils.add(links, StringUtils.substringAfterLast(finalReferencedMessage, protocol));
 					}
+					for (String link : links) {
+						if (link.contains("\n")) {
+							link = StringUtils.substringBefore(link, "\n");
+						}
 
-					String hyperlinkInsert = textAfterPlaceholder + "},{\"text\":\"http://" + link + "\",\"bold\":false,\"underlined\":true,\"color\":\"yellow\",\"clickEvent\":{\"action\":\"open_url\",\"value\":\"" + "http://" + link + "\"},\"hoverEvent\":{\"action\":\"show_text\",\"contents\":[{\"text\":\"Open URL\"}]}},{" + textBeforePlaceholder;
-					finalReferencedMessage = StringUtils.replaceIgnoreCase(finalReferencedMessage, ("http://" + link), hyperlinkInsert);
-				}
-			}
-
-			if (finalReferencedMessage.contains("https://")) {
-				String[] links = StringUtils.substringsBetween(finalReferencedMessage, "https://", " ");
-				if (!StringUtils.substringAfterLast(referencedMessage.toString(), "https://").contains(" ")) {
-					links = ArrayUtils.add(links, StringUtils.substringAfterLast(referencedMessage.toString(), "https://"));
-				}
-				for (String link : links) {
-					if (link.contains("\n")) {
-						link = StringUtils.substringBefore(link, "\n");
+						String hyperlinkInsert;
+						if (StringUtils.containsIgnoreCase(link, "gif")
+								&& StringUtils.containsIgnoreCase(link, "tenor.com")) {
+							hyperlinkInsert = textAfterPlaceholder + "},{\"text\":\"<gif>\",\"bold\":false,\"underlined\":true,\"color\":\"yellow\",\"clickEvent\":{\"action\":\"open_url\",\"value\":\"" + protocol + link + "\"},\"hoverEvent\":{\"action\":\"show_text\",\"contents\":[{\"text\":\"Open URL\"}]}},{" + textBeforePlaceholder;
+						} else {
+							hyperlinkInsert = textAfterPlaceholder + "},{\"text\":\"" + protocol + link + "\",\"bold\":false,\"underlined\":true,\"color\":\"yellow\",\"clickEvent\":{\"action\":\"open_url\",\"value\":\"" + protocol + link + "\"},\"hoverEvent\":{\"action\":\"show_text\",\"contents\":[{\"text\":\"Open URL\"}]}},{" + textBeforePlaceholder;
+						}
+						finalReferencedMessage = StringUtils.replaceIgnoreCase(finalReferencedMessage, (protocol + link), hyperlinkInsert);
 					}
-
-					String hyperlinkInsert = textAfterPlaceholder + "},{\"text\":\"https://" + link + "\",\"bold\":false,\"underlined\":true,\"color\":\"yellow\",\"clickEvent\":{\"action\":\"open_url\",\"value\":\"" + "https://" + link + "\"},\"hoverEvent\":{\"action\":\"show_text\",\"contents\":[{\"text\":\"Open URL\"}]}},{" + textBeforePlaceholder;
-					finalReferencedMessage = StringUtils.replaceIgnoreCase(finalReferencedMessage, ("https://" + link), hyperlinkInsert);
 				}
 			}
 		}
@@ -434,6 +424,15 @@ public class DiscordEventListener extends ListenerAdapter {
 				} else {
 					message.append("file>");
 				}
+			}
+		}
+
+		if (!e.getMessage().getStickers().isEmpty()) {
+			if (!e.getMessage().getContentDisplay().isBlank()) {
+				message.append(" ");
+			}
+			for (MessageSticker ignored : e.getMessage().getStickers()) {
+				message.append(Formatting.YELLOW).append("<sticker>");
 			}
 		}
 
@@ -466,33 +465,26 @@ public class DiscordEventListener extends ListenerAdapter {
 
 		String finalMessage = MarkdownParser.parseMarkdown(message.toString());
 
-		if (finalMessage.contains("http://")) {
-			String[] links = StringUtils.substringsBetween(finalMessage, "http://", " ");
-			if (!StringUtils.substringAfterLast(finalMessage, "http://").contains(" ")) {
-				links = ArrayUtils.add(links, StringUtils.substringAfterLast(finalMessage, "http://"));
-			}
-			for (String link : links) {
-				if (link.contains("\n")) {
-					link = StringUtils.substringBefore(link, "\n");
+		for (String protocol : new String[]{"http://", "https://"}) {
+			if (finalMessage.contains(protocol)) {
+				String[] links = StringUtils.substringsBetween(finalMessage, protocol, " ");
+				if (!StringUtils.substringAfterLast(finalMessage, protocol).contains(" ")) {
+					links = ArrayUtils.add(links, StringUtils.substringAfterLast(finalMessage, protocol));
 				}
+				for (String link : links) {
+					if (link.contains("\n")) {
+						link = StringUtils.substringBefore(link, "\n");
+					}
 
-				String hyperlinkInsert = textAfterPlaceholder + "},{\"text\":\"http://" + link + "\",\"bold\":false,\"underlined\":true,\"color\":\"yellow\",\"clickEvent\":{\"action\":\"open_url\",\"value\":\"" + "http://" + link + "\"},\"hoverEvent\":{\"action\":\"show_text\",\"contents\":[{\"text\":\"Open URL\"}]}},{" + textBeforePlaceholder;
-				finalMessage = StringUtils.replaceIgnoreCase(finalMessage, ("http://" + link), hyperlinkInsert);
-			}
-		}
-
-		if (finalMessage.contains("https://")) {
-			String[] links = StringUtils.substringsBetween(finalMessage, "https://", " ");
-			if (!StringUtils.substringAfterLast(finalMessage, "https://").contains(" ")) {
-				links = ArrayUtils.add(links, StringUtils.substringAfterLast(finalMessage, "https://"));
-			}
-			for (String link : links) {
-				if (link.contains("\n")) {
-					link = StringUtils.substringBefore(link, "\n");
+					String hyperlinkInsert;
+					if (StringUtils.containsIgnoreCase(link, "gif")
+							&& StringUtils.containsIgnoreCase(link, "tenor.com")) {
+						hyperlinkInsert = textAfterPlaceholder + "},{\"text\":\"<gif>\",\"bold\":false,\"underlined\":true,\"color\":\"yellow\",\"clickEvent\":{\"action\":\"open_url\",\"value\":\"" + protocol + link + "\"},\"hoverEvent\":{\"action\":\"show_text\",\"contents\":[{\"text\":\"Open URL\"}]}},{" + textBeforePlaceholder;
+					} else {
+						hyperlinkInsert = textAfterPlaceholder + "},{\"text\":\"" + protocol + link + "\",\"bold\":false,\"underlined\":true,\"color\":\"yellow\",\"clickEvent\":{\"action\":\"open_url\",\"value\":\"" + protocol + link + "\"},\"hoverEvent\":{\"action\":\"show_text\",\"contents\":[{\"text\":\"Open URL\"}]}},{" + textBeforePlaceholder;
+					}
+					finalMessage = StringUtils.replaceIgnoreCase(finalMessage, (protocol + link), hyperlinkInsert);
 				}
-
-				String hyperlinkInsert = textAfterPlaceholder + "},{\"text\":\"https://" + link + "\",\"bold\":false,\"underlined\":true,\"color\":\"yellow\",\"clickEvent\":{\"action\":\"open_url\",\"value\":\"" + "https://" + link + "\"},\"hoverEvent\":{\"action\":\"show_text\",\"contents\":[{\"text\":\"Open URL\"}]}},{" + textBeforePlaceholder;
-				finalMessage = StringUtils.replaceIgnoreCase(finalMessage, ("https://" + link), hyperlinkInsert);
 			}
 		}
 

--- a/src/main/java/top/xujiayao/mcdiscordchat/discord/DiscordEventListener.java
+++ b/src/main/java/top/xujiayao/mcdiscordchat/discord/DiscordEventListener.java
@@ -355,7 +355,6 @@ public class DiscordEventListener extends ListenerAdapter {
 
 			// ignore Discord's built in gifs, can only be one
 			if (StringUtils.startsWith(referencedMessage, "https://")
-					&& StringUtils.endsWith(referencedMessage, ".gif")
 					&& StringUtils.contains(referencedMessage, "tenor.com")) {
 				referencedMessage.append(Formatting.YELLOW).append("<gif>");
 			}

--- a/src/main/java/top/xujiayao/mcdiscordchat/discord/DiscordEventListener.java
+++ b/src/main/java/top/xujiayao/mcdiscordchat/discord/DiscordEventListener.java
@@ -9,6 +9,7 @@ import com.vdurmont.emoji.EmojiParser;
 import net.dv8tion.jda.api.entities.Emote;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageSticker;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -344,6 +345,17 @@ public class DiscordEventListener extends ListenerAdapter {
 						referencedMessage.append("file>");
 					}
 				}
+			}
+
+			if (!e.getMessage().getReferencedMessage().getStickers().isEmpty()) {
+				for (MessageSticker sticker : e.getMessage().getReferencedMessage().getStickers()) {
+					referencedMessage.append(Formatting.YELLOW).append("<sticker>");
+				}
+			}
+
+			// ignore Discord's built in gifs, can only be one
+			if (StringUtils.startsWith(referencedMessage, "https://tenor.com/view")) {
+				referencedMessage.append("<gif>");
 			}
 
 			if (StringUtils.countMatches(referencedMessage, ":") >= 2) {

--- a/src/main/java/top/xujiayao/mcdiscordchat/minecraft/mixins/MixinServerPlayNetworkHandler.java
+++ b/src/main/java/top/xujiayao/mcdiscordchat/minecraft/mixins/MixinServerPlayNetworkHandler.java
@@ -148,34 +148,26 @@ public abstract class MixinServerPlayNetworkHandler {
 				if (CONFIG.generic.modifyChatMessages) {
 					contentToMinecraft = MarkdownParser.parseMarkdown(contentToMinecraft);
 
-					if (contentToMinecraft.contains("http://")) {
-						String[] links = StringUtils.substringsBetween(contentToMinecraft, "http://", " ");
-						if (!StringUtils.substringAfterLast(contentToMinecraft, "http://").contains(" ")) {
-							links = ArrayUtils.add(links, StringUtils.substringAfterLast(contentToMinecraft, "http://"));
-						}
-						for (String link : links) {
-							if (link.contains("\n")) {
-								link = StringUtils.substringBefore(link, "\n");
+					for (String protocol : new String[]{"http://", "https://"}) {
+						if (contentToMinecraft.contains(protocol)) {
+							String[] links = StringUtils.substringsBetween(contentToMinecraft, protocol, " ");
+							if (!StringUtils.substringAfterLast(contentToMinecraft, protocol).contains(" ")) {
+								links = ArrayUtils.add(links, StringUtils.substringAfterLast(contentToMinecraft, protocol));
 							}
+							for (String link : links) {
+								if (link.contains("\n")) {
+									link = StringUtils.substringBefore(link, "\n");
+								}
 
-							String hyperlinkInsert = "\"},{\"text\":\"http://" + link + "\",\"underlined\":true,\"color\":\"yellow\",\"clickEvent\":{\"action\":\"open_url\",\"value\":\"" + "http://" + link + "\"},\"hoverEvent\":{\"action\":\"show_text\",\"contents\":[{\"text\":\"Open URL\"}]}},{\"text\":\"";
-							contentToMinecraft = StringUtils.replaceIgnoreCase(contentToMinecraft, ("http://" + link), hyperlinkInsert);
-						}
-					}
-
-					if (contentToMinecraft.contains("https://")) {
-						String[] links = StringUtils.substringsBetween(contentToMinecraft, "https://", " ");
-						if (!StringUtils.substringAfterLast(contentToMinecraft, "https://").contains(" ")) {
-							links = ArrayUtils.add(links, StringUtils.substringAfterLast(contentToMinecraft, "https://"));
-						}
-
-						for (String link : links) {
-							if (link.contains("\n")) {
-								link = StringUtils.substringBefore(link, "\n");
+								String hyperlinkInsert;
+								if (StringUtils.containsIgnoreCase(link, "gif")
+										&& StringUtils.containsIgnoreCase(link, "tenor.com")) {
+									hyperlinkInsert = "\"},{\"text\":\"<gif>\",\"underlined\":true,\"color\":\"yellow\",\"clickEvent\":{\"action\":\"open_url\",\"value\":\"" + protocol + link + "\"},\"hoverEvent\":{\"action\":\"show_text\",\"contents\":[{\"text\":\"Open URL\"}]}},{\"text\":\"";
+								} else {
+									hyperlinkInsert = "\"},{\"text\":\"" + protocol + link + "\",\"underlined\":true,\"color\":\"yellow\",\"clickEvent\":{\"action\":\"open_url\",\"value\":\"" + protocol + link + "\"},\"hoverEvent\":{\"action\":\"show_text\",\"contents\":[{\"text\":\"Open URL\"}]}},{\"text\":\"";
+								}
+								contentToMinecraft = StringUtils.replaceIgnoreCase(contentToMinecraft, (protocol + link), hyperlinkInsert);
 							}
-
-							String hyperlinkInsert = "\"},{\"text\":\"https://" + link + "\",\"underlined\":true,\"color\":\"yellow\",\"clickEvent\":{\"action\":\"open_url\",\"value\":\"" + "https://" + link + "\"},\"hoverEvent\":{\"action\":\"show_text\",\"contents\":[{\"text\":\"Open URL\"}]}},{\"text\":\"";
-							contentToMinecraft = StringUtils.replaceIgnoreCase(contentToMinecraft, ("https://" + link), hyperlinkInsert);
 						}
 					}
 


### PR DESCRIPTION
## Changes
In the same way exclusion was added for files/images, add it for stickers and gifs.
This is only added for Discord's built in gifs using the GIF menu.

## Example
Currently stickers will appear as nothing, simply no text.
![image](https://user-images.githubusercontent.com/35664724/175924606-58a38b5a-be76-422c-8bc7-868e62eae3e4.png)
![image](https://user-images.githubusercontent.com/35664724/175924616-8d3d28c0-9e76-4fec-8b62-0bf701b4cf4c.png)

Gifs will appear as their full links in chat
![image](https://user-images.githubusercontent.com/35664724/175924556-6b5d9f15-05e3-4f20-968a-20a3c0c9d310.png)
