### PR TITLE
[Bug] fix JDA hangs ~10 min on server stop

### DIFF
--- a/src/main/java/top/xujiayao/mcdiscordchat/Config.java
+++ b/src/main/java/top/xujiayao/mcdiscordchat/Config.java
@@ -60,6 +60,8 @@ public class Config {
 		public boolean updateChannelTopic = true;
 		public int channelTopicUpdateInterval = 600000;
 
+		public boolean shutdownImmediately = false;
+
 		public List<String> excludedCommands = List.of("/msg", "/tell", "/tellraw", "/w");
 
 		public List<String> adminsIds = new ArrayList<>();

--- a/src/main/java/top/xujiayao/mcdiscordchat/Main.java
+++ b/src/main/java/top/xujiayao/mcdiscordchat/Main.java
@@ -167,50 +167,24 @@ public class Main implements DedicatedServerModInitializer {
 			}
 
 			if (CONFIG.generic.updateChannelTopic) {
-				if (CONFIG.generic.announceServerStartStop) {
-					CHANNEL.sendMessage(Translations.translateMessage("message.serverStopped"))
-							.submit()
-							.whenComplete((v, ex) -> {
-								String topic = Translations.translateMessage("message.offlineChannelTopic")
-										.replace("%lastUpdateTime%", Long.toString(Instant.now().getEpochSecond()));
+					
+				String topic = Translations.translateMessage("message.offlineChannelTopic")
+						.replace("%lastUpdateTime%", Long.toString(Instant.now().getEpochSecond()));
 
-								CHANNEL.getManager().setTopic(topic)
-										.submit()
-										.whenComplete((v2, ex2) -> {
-											if (!CONFIG.generic.consoleLogChannelId.isEmpty()) {
-												CONSOLE_LOG_CHANNEL.getManager().setTopic(topic)
-														.submit()
-														.whenComplete((v3, ex3) -> JDA.shutdownNow());
-											} else {
-												JDA.shutdownNow();
-											}
-										});
-							});
-				} else {
-					String topic = Translations.translateMessage("message.offlineChannelTopic")
-							.replace("%lastUpdateTime%", Long.toString(Instant.now().getEpochSecond()));
-
-					CHANNEL.getManager().setTopic(topic)
-							.submit()
-							.whenComplete((v2, ex2) -> {
-								if (!CONFIG.generic.consoleLogChannelId.isEmpty()) {
-									CONSOLE_LOG_CHANNEL.getManager().setTopic(topic)
-											.submit()
-											.whenComplete((v3, ex3) -> JDA.shutdownNow());
-								} else {
-									JDA.shutdownNow();
-								}
-							});
-				}
-			} else {
-				if (CONFIG.generic.announceServerStartStop) {
-					CHANNEL.sendMessage(Translations.translateMessage("message.serverStopped"))
-							.submit()
-							.whenComplete((v, ex) -> JDA.shutdownNow());
-				} else {
-					JDA.shutdownNow();
-				}
+				CHANNEL.getManager().setTopic(topic).queue();		
+				
 			}
+				
+			if (CONFIG.generic.announceServerStartStop) {
+				CHANNEL.sendMessage(Translations.translateMessage("message.serverStopped"))
+						.submit()
+						.whenComplete((v3, ex3) -> JDA.shutdownNow());					
+			} else {
+				JDA.shutdownNow();
+			}
+
+			HTTP_CLIENT.connectionPool().evictAll();
+			HTTP_CLIENT.dispatcher().executorService().shutdown();
 		});
 	}
 }

--- a/src/main/java/top/xujiayao/mcdiscordchat/Main.java
+++ b/src/main/java/top/xujiayao/mcdiscordchat/Main.java
@@ -167,18 +167,19 @@ public class Main implements DedicatedServerModInitializer {
 			}
 
 			if (CONFIG.generic.updateChannelTopic) {
-					
 				String topic = Translations.translateMessage("message.offlineChannelTopic")
 						.replace("%lastUpdateTime%", Long.toString(Instant.now().getEpochSecond()));
 
-				CHANNEL.getManager().setTopic(topic).queue();		
-				
+				CHANNEL.getManager().setTopic(topic).queue();
+				if (!CONFIG.generic.consoleLogChannelId.isEmpty()) {
+					CONSOLE_LOG_CHANNEL.getManager().setTopic(topic).queue();
+				}
 			}
-				
+
 			if (CONFIG.generic.announceServerStartStop) {
 				CHANNEL.sendMessage(Translations.translateMessage("message.serverStopped"))
 						.submit()
-						.whenComplete((v3, ex3) -> JDA.shutdownNow());					
+						.whenComplete((v, ex) -> JDA.shutdownNow());
 			} else {
 				JDA.shutdownNow();
 			}


### PR DESCRIPTION
<!-- New Feature or Bug Fix Pull Request -->
<!-- Implement an idea for this project or implement a bug fix to help us improve. -->
<!---->
<!-- Insert "[Enhancement] " or "[Bug] " before the first word in the title. -->
<!-- Note that the PR may be closed directly if you do not follow the instructions. -->

### Checks

<!-- Please check that you have done the following things before submitting a pull request. -->
<!-- Set [ ] to [X] -->

- [X] I confirm that I have [searched for existing issues / pull requests](https://github.com/Xujiayao/MCDiscordChat/issues?q=) before requesting to avoid duplicate requesting.
- [X] I confirm that I noted that if I don't follow the instructions, the issue may be closed directly.

### Description

Hi @Xujiayao, hope you're doing well.

Because of the activation of the udpateTopic feature and in some case, the JVM is kept running several minutes after the server has stopped. There's absolutely no log from the mod when the problem occurs.

It seems to be cause by the high rate limit on the discord endpoint api used to update a channel's topic and the fact that MCDC wait for the update to be complete before shutting down the JDA instance. (after quick research, same problem encountered on some other discord integration mod/plugin) 

In this fix, the topic update is queued and the mod does not wait anymore for the completion of the future. I also explicitly terminated the HTTPClient instance used by JDA to be sure that, in any case, it will not kept the JVM running after the shutdown. ([JDA Doc](https://jda.wiki/using-jda/troubleshooting/#shutdown-but-the-process-doesnt-exit))

I think there's not over way to avoid this issue due to the discord endpoint rate limit. We could probably add a new config key to let the user free to decide if he wants the server to wait the topic update before shutting down or not.

I hope i didn't miss anything... Feel free to ask if any change need :)


