### PR TITLE
[Enhancement] Improve console log formatting

### DIFF
--- a/src/main/java/top/xujiayao/mcdiscordchat/utils/ConsoleLogListener.java
+++ b/src/main/java/top/xujiayao/mcdiscordchat/utils/ConsoleLogListener.java
@@ -29,7 +29,7 @@ import static top.xujiayao.mcdiscordchat.Main.MINECRAFT_SEND_COUNT;
 public class ConsoleLogListener implements Runnable {
 
 	private final        boolean readFileHistory;
-	private static final Pattern newlinePattern = Pattern.compile("\n");
+	private static final Pattern newlinePattern = Pattern.compile("\n+");
 	private static final Pattern formatPattern = Pattern.compile("§.");
 
 	public ConsoleLogListener(boolean readFileHistory) {
@@ -137,7 +137,7 @@ public class ConsoleLogListener implements Runnable {
 		}
 
 		message = "`" + message + "`";
-		message = newlinePattern.matcher(message).replaceAll("`\n`");
+		message = newlinePattern.matcher(message).replaceAll("`$0`");
 
 		if ((System.currentTimeMillis() - MINECRAFT_LAST_RESET_TIME) > 20_000) {
 			MINECRAFT_SEND_COUNT = 0;

--- a/src/main/java/top/xujiayao/mcdiscordchat/utils/ConsoleLogListener.java
+++ b/src/main/java/top/xujiayao/mcdiscordchat/utils/ConsoleLogListener.java
@@ -28,7 +28,7 @@ import static top.xujiayao.mcdiscordchat.Main.MINECRAFT_SEND_COUNT;
  */
 public class ConsoleLogListener implements Runnable {
 
-	private final        boolean readFileHistory;
+	private final boolean readFileHistory;
 	private static final Pattern newlinePattern = Pattern.compile("\n+");
 	private static final Pattern formatPattern = Pattern.compile("§.");
 

--- a/src/main/java/top/xujiayao/mcdiscordchat/utils/ConsoleLogListener.java
+++ b/src/main/java/top/xujiayao/mcdiscordchat/utils/ConsoleLogListener.java
@@ -88,13 +88,10 @@ public class ConsoleLogListener implements Runnable {
 
 								while (messageBatch.length() + currentLine.length() < 1900) {
 									// create the message batch
-									messageBatch.append(currentLine);
-									messageBatch.append("\n");
+									appendLine(messageBatch, currentLine);
 
 									if (newMessageIterator.hasNext()) {
 										currentLine = newMessageIterator.next();
-										currentLine =
-												formatPattern.matcher(currentLine).replaceAll("");
 									} else {
 										finishedSendingMessages = true;
 										break;
@@ -103,8 +100,7 @@ public class ConsoleLogListener implements Runnable {
 
 								if (messageBatch.isEmpty()) {
 									// currentLine is somehow larger than char limit
-									messageBatch.append(currentLine);
-									messageBatch.append("\n");
+									appendLine(messageBatch, currentLine);
 								}
 
 								if (!messageBatch.isEmpty()) {
@@ -127,6 +123,12 @@ public class ConsoleLogListener implements Runnable {
 			CONSOLE_LOG_CHANNEL.sendMessage(Translations.translate("utils.clListener.stopListening")).queue();
 			LOGGER.info("[ConsoleLog] Closing ConsoleLogListener");
 		}
+	}
+
+	private void appendLine(StringBuilder messageBatch, String currentLine) {
+		currentLine = formatPattern.matcher(currentLine).replaceAll("");
+		messageBatch.append(currentLine);
+		messageBatch.append("\n");
 	}
 
 	private void sendLogChannelMessage(String message) {

--- a/src/main/java/top/xujiayao/mcdiscordchat/utils/ConsoleLogListener.java
+++ b/src/main/java/top/xujiayao/mcdiscordchat/utils/ConsoleLogListener.java
@@ -38,7 +38,7 @@ public class ConsoleLogListener implements Runnable {
 
 	@Override
 	public void run() {
-		sendLogChannelMessage(Translations.translate("utils.clListener.startListening"));
+		CONSOLE_LOG_CHANNEL.sendMessage(Translations.translate("utils.clListener.startListening")).queue();
 		LOGGER.info("[ConsoleLog] Starting new ConsoleLogListener");
 
 		final File file = new File(FabricLoader.getInstance().getGameDir().toString() + "/logs/latest.log");
@@ -124,7 +124,7 @@ public class ConsoleLogListener implements Runnable {
 				}
 			}
 		} finally {
-			sendLogChannelMessage(Translations.translate("utils.clListener.stopListening"));
+			CONSOLE_LOG_CHANNEL.sendMessage(Translations.translate("utils.clListener.stopListening")).queue();
 			LOGGER.info("[ConsoleLog] Closing ConsoleLogListener");
 		}
 	}


### PR DESCRIPTION
### Checks

- [X] I confirm that I have [searched for existing issues / pull requests](https://github.com/Xujiayao/MCDiscordChat/issues?q=) before requesting to avoid duplicate requesting.
- [X] I confirm that I noted that if I don't follow the instructions, the issue may be closed directly.

### Related Issues

N/A

### Description

This PR changes the log messages sent to Discord to be inline code blocks instead of plain text. This fixes some formatting errors, makes text designs that rely on constant-width characters look better, and generally just looks cleaner. It also removes the format character codes `§` before sending messages to Discord.

Discord recently enabled markdown list formatting in messages, which breaks the mod list formatting on server startup:

Old:
![image](https://github.com/Xujiayao/MCDiscordChat/assets/46658877/e09b9f29-0780-4ff8-80a2-5b8a8ca191cb)
New:
![image](https://github.com/Xujiayao/MCDiscordChat/assets/46658877/267085c3-3c62-46c8-be34-bf5b44340a60)

Other text and designs, such as the luckperms logo, can break if sent in plain text:

Old:
![image](https://github.com/Xujiayao/MCDiscordChat/assets/46658877/09f54aef-b013-4918-a16c-6265446d4641)
New:
![image](https://github.com/Xujiayao/MCDiscordChat/assets/46658877/612e2b95-882c-4032-9b27-be761856202e)

