### PR TITLE
[Bug] Fix error from long messages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: build
-on: [ push ]
+on: [ pull_request, push ]
 
 jobs:
   build:


### PR DESCRIPTION
### Checks

- [X] I confirm that I have [searched for existing issues / pull requests](https://github.com/Xujiayao/MCDiscordChat/issues?q=) before requesting to avoid duplicate requesting.
- [X] I confirm that I noted that if I don't follow the instructions, the issue may be closed directly.

### Related Issues

Fixes #110 
Fixes #148 

### Description

Fixes the issue when individual lines in the console exceed the character limit for a message. The index error was fixed by changes in #140 , but long lines were truncated, and ConsoleLogListener would still re-send all previous messages when restarting from an error. This changes the behavior so long lines are now split and sent to discord as multiple messages, and if ConsoleLogListener runs into an error, it will restart without repeating previous messages.