### PR TITLE
[Bug] Fix NPE if player is registered before SERVER field set

### DIFF
--- a/src/main/java/top/xujiayao/mcdiscordchat/utils/Utils.java
+++ b/src/main/java/top/xujiayao/mcdiscordchat/utils/Utils.java
@@ -341,6 +341,10 @@ public class Utils {
 	}
 
 	public static void setBotActivity() {
+		if (SERVER == null) {
+			// Bot is registered before official server start
+			return;
+		}
 		if (!CONFIG.generic.botPlayingStatus.isEmpty()) {
 			JDA.getPresence().setActivity(Activity.playing(CONFIG.generic.botPlayingStatus
 					.replace("%onlinePlayerCount%", Integer.toString(SERVER.getPlayerManager().getPlayerList().size()))


### PR DESCRIPTION
<!-- New Feature or Bug Fix Pull Request -->
<!-- Implement an idea for this project or implement a bug fix to help us improve. -->
<!---->
<!-- Insert "[Enhancement] " or "[Bug] " before the first word in the title. -->
<!-- Note that the PR may be closed directly if you do not follow the instructions. -->

### Checks

<!-- Please check that you have done the following things before submitting a pull request. -->
<!-- Set [ ] to [X] -->

- [X] I confirm that I have [searched for existing issues / pull requests](https://github.com/Xujiayao/MCDiscordChat/issues?q=) before requesting to avoid duplicate requesting.
- [X] I confirm that I noted that if I don't follow the instructions, the issue may be closed directly.


### Related Issues

N/A

### Description

When it is used with [EssentialAddons](https://github.com/Super-Santa/EssentialAddons) / or possibly Bot-reloading mods, it may try to find undefined SERVER and cause NPE.

Here is stack trace:
```
java.lang.NullPointerException: Cannot invoke "net.minecraft.server.MinecraftServer.method_3760()" because "top.xujiayao.mcdiscordchat.Main.SERVER" is null
    at top.xujiayao.mcdiscordchat.utils.Utils.setBotActivity(Utils.java:346) ~[mcdiscordchat-1_20_x-2.2.0-a47a716b5f3984a3.jar:?]
    at net.minecraft.class_3324.handler$coe000$mcdiscordchat-1_20_x$onPlayerConnect(class_3324.java:5093) ~[server-intermediary.jar:?]
    at net.minecraft.class_3324.method_14570(class_3324.java:307) ~[server-intermediary.jar:?]
    at carpet.patches.EntityPlayerMPFake.join(EntityPlayerMPFake.java:1081) ~[fabric-carpet-1.20-1.4.112+v230608.jar:?]
    at essentialaddons.feature.ReloadFakePlayers.loadPlayer(ReloadFakePlayers.java:51) ~[essentialaddons-1.20.1-1.2.1.jar:?]
    at essentialaddons.utils.ConfigFakePlayerData.lambda$readConfig$3(ConfigFakePlayerData.java:108) ~[essentialaddons-1.20.1-1.2.1.jar:?]
    at java.lang.Iterable.forEach(Unknown Source) ~[?:?]
    at essentialaddons.utils.ConfigFakePlayerData.readConfig(ConfigFakePlayerData.java:82) ~[essentialaddons-1.20.1-1.2.1.jar:?]
    at essentialaddons.feature.ReloadFakePlayers.loadFakePlayers(ReloadFakePlayers.java:26) ~[essentialaddons-1.20.1-1.2.1.jar:?]
    at essentialaddons.EssentialAddons.onServerLoadedWorlds(EssentialAddons.java:84) ~[essentialaddons-1.20.1-1.2.1.jar:?]
    at java.lang.Thread.run(Unknown Source) ~[?:?]
```

After simple fix, it does not happen.
This is fairly simple one-line change, so you can just feel free to change one line by yourself.

<!-- For Bug Fix Pull Request: -->
<!-- Please tell us what bug have you fixed with a clear and detailed description, add screenshots to help explain. -->
<!---->
<!-- For New Feature Pull Request: -->
<!-- What new feature or change have you added? What does it improve? Please tell us what the new feature or change is with a clear and detailed description, add screenshots to help explain if possible. -->